### PR TITLE
Update Firebase secret usage

### DIFF
--- a/.github/workflows/firebase-hosting.yml
+++ b/.github/workflows/firebase-hosting.yml
@@ -1,0 +1,31 @@
+name: Deploy to Firebase Hosting
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  build-and-deploy:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ./encyclopedia
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+      - name: Install dependencies
+        run: npm ci
+      - name: Build
+        run: npm run build -- --configuration production
+      - name: Deploy to Firebase Hosting
+        uses: FirebaseExtended/action-hosting-deploy@v0
+        with:
+          firebaseToken: '${{ secrets.FIREBASE_TOKEN }}'
+          channelId: live
+        env:
+          FIREBASE_CLI_PREVIEWS: hostingchannels
+

--- a/README.md
+++ b/README.md
@@ -1,1 +1,10 @@
 # Novel-Encyclopedia
+
+This repository contains an Angular project located under `encyclopedia/`. The application is automatically deployed to Firebase Hosting on each push to the `main` branch via GitHub Actions. The production build output is located in `encyclopedia/dist/encyclopedia/browser` and served through Firebase Hosting.
+
+To enable deployments, create the following GitHub secrets in your repository:
+
+- `FIREBASE_SERVICE_ACCOUNT` – JSON service account for your Firebase project
+- `FIREBASE_PROJECT_ID` – Firebase project ID
+
+

--- a/encyclopedia/firebase.json
+++ b/encyclopedia/firebase.json
@@ -1,1 +1,14 @@
-{}
+{
+  "hosting": {
+    "public": "dist/encyclopedia/browser",
+    "ignore": [
+      "firebase.json",
+      "**/.*",
+      "**/node_modules/**"
+    ],
+    "rewrites": [
+      { "source": "**", "destination": "/index.html" }
+    ]
+  }
+}
+


### PR DESCRIPTION
## Summary
- update Firebase Hosting action to use `FIREBASE_TOKEN`

## Testing
- `npm ci --ignore-scripts` *(fails: command interrupted)*


------
https://chatgpt.com/codex/tasks/task_e_684420599724832e815b37e99a46c541