### PR TITLE
Update Firebase docs

### DIFF
--- a/.github/workflows/firebase-hosting.yml
+++ b/.github/workflows/firebase-hosting.yml
@@ -1,0 +1,32 @@
+name: Deploy to Firebase Hosting
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  build-and-deploy:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ./encyclopedia
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+          cache-dependency-path: encyclopedia/package-lock.json
+      - name: Install dependencies
+        run: npm ci
+      - name: Build
+        run: npm run build -- --configuration production
+      - name: Deploy to Firebase Hosting
+        uses: FirebaseExtended/action-hosting-deploy@v0
+        with:
+          firebaseToken: '${{ secrets.FIREBASE_TOKEN }}'
+          channelId: live
+        env:
+          FIREBASE_CLI_PREVIEWS: hostingchannels
+

--- a/README.md
+++ b/README.md
@@ -1,1 +1,9 @@
 # Novel-Encyclopedia
+
+This repository contains an Angular project located under `encyclopedia/`. The application is automatically deployed to Firebase Hosting on each push to the `main` branch via GitHub Actions. The production build output is located in `encyclopedia/dist/encyclopedia/browser` and served through Firebase Hosting.
+
+To enable deployments, create the following GitHub secret in your repository:
+
+- `FIREBASE_TOKEN` – Firebase CI token generated via `firebase login:ci`
+
+

--- a/encyclopedia/firebase.json
+++ b/encyclopedia/firebase.json
@@ -1,1 +1,14 @@
-{}
+{
+  "hosting": {
+    "public": "dist/encyclopedia/browser",
+    "ignore": [
+      "firebase.json",
+      "**/.*",
+      "**/node_modules/**"
+    ],
+    "rewrites": [
+      { "source": "**", "destination": "/index.html" }
+    ]
+  }
+}
+


### PR DESCRIPTION
## Summary
- clarify that the deployment workflow uses the `FIREBASE_TOKEN` secret

## Testing
- `npm ci --ignore-scripts`
- `npm run build -- --configuration production`


------
https://chatgpt.com/codex/tasks/task_e_684420599724832e815b37e99a46c541