### PR TITLE
Implement core encyclopedia features

### DIFF
--- a/encyclopedia/src/app/app.component.html
+++ b/encyclopedia/src/app/app.component.html
@@ -1,1 +1,5 @@
+<nav>
+  <a routerLink="/home">Home</a>
+  <a routerLink="/entries">Entries</a>
+</nav>
 <router-outlet></router-outlet>

--- a/encyclopedia/src/app/app.component.scss
+++ b/encyclopedia/src/app/app.component.scss
@@ -1,0 +1,10 @@
+nav {
+  background: #eae3d8;
+  padding: 0.5rem 1rem;
+  display: flex;
+  gap: 1rem;
+  a {
+    text-decoration: none;
+    color: #333;
+  }
+}

--- a/encyclopedia/src/app/app.component.ts
+++ b/encyclopedia/src/app/app.component.ts
@@ -1,10 +1,10 @@
 import { Component } from '@angular/core';
-import { RouterOutlet } from '@angular/router';
+import { RouterOutlet, RouterLink } from '@angular/router';
 
 @Component({
   selector: 'app-root',
   standalone: true,
-  imports: [RouterOutlet],
+  imports: [RouterOutlet, RouterLink],
   templateUrl: './app.component.html',
   styleUrl: './app.component.scss'
 })

--- a/encyclopedia/src/app/app.routes.ts
+++ b/encyclopedia/src/app/app.routes.ts
@@ -3,4 +3,8 @@ import { Routes } from '@angular/router';
 export const routes: Routes = [
   { path: '', redirectTo: 'home', pathMatch: 'full' },
   { path: 'home', loadComponent: () => import('./components/home/home.component').then(m => m.HomeComponent) },
+  { path: 'entries', loadComponent: () => import('./components/entries/entries.component').then(m => m.EntriesComponent) },
+  { path: 'entries/new', loadComponent: () => import('./components/entry-form/entry-form.component').then(m => m.EntryFormComponent) },
+  { path: 'entries/:id', loadComponent: () => import('./components/entry-detail/entry-detail.component').then(m => m.EntryDetailComponent) },
+  { path: 'entries/:id/edit', loadComponent: () => import('./components/entry-form/entry-form.component').then(m => m.EntryFormComponent) },
 ];

--- a/encyclopedia/src/app/components/entries/entries.component.html
+++ b/encyclopedia/src/app/components/entries/entries.component.html
@@ -1,0 +1,11 @@
+<h2>Entries</h2>
+<div class="entries">
+  <a *ngFor="let entry of entries$ | async" [routerLink]="['/entries', entry.id]" class="entry-link">
+    <h3>{{entry.title}}</h3>
+    <p class="type">{{entry.type}}</p>
+  </a>
+</div>
+<p class="empty" *ngIf="(entries$ | async)?.length === 0">No entries yet.</p>
+<p>
+  <a routerLink="/entries/new">Add New Entry</a>
+</p>

--- a/encyclopedia/src/app/components/entries/entries.component.scss
+++ b/encyclopedia/src/app/components/entries/entries.component.scss
@@ -1,0 +1,20 @@
+.entries {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+}
+.entry-link {
+  flex: 1 1 200px;
+  padding: 1rem;
+  background: #f8f5f0;
+  border: 1px solid #ddd5c4;
+  text-decoration: none;
+  color: inherit;
+}
+.type {
+  font-size: 0.8rem;
+  color: #6a5d4d;
+}
+.empty {
+  font-style: italic;
+}

--- a/encyclopedia/src/app/components/entries/entries.component.ts
+++ b/encyclopedia/src/app/components/entries/entries.component.ts
@@ -1,0 +1,19 @@
+import { CommonModule } from '@angular/common';
+import { Component } from '@angular/core';
+import { RouterModule } from '@angular/router';
+import { Observable } from 'rxjs';
+import { Entry } from '../../models/entry';
+import { EntryService } from '../../services/entry.service';
+
+@Component({
+  selector: 'app-entries',
+  standalone: true,
+  imports: [CommonModule, RouterModule],
+  templateUrl: './entries.component.html',
+  styleUrls: ['./entries.component.scss']
+})
+export class EntriesComponent {
+  entries$: Observable<Entry[]> = this.entryService.getEntries();
+
+  constructor(private entryService: EntryService) {}
+}

--- a/encyclopedia/src/app/components/entry-detail/entry-detail.component.html
+++ b/encyclopedia/src/app/components/entry-detail/entry-detail.component.html
@@ -1,0 +1,20 @@
+<div *ngIf="entry$ | async as entry; else loading">
+  <h2>{{ entry.title }}</h2>
+  <p class="type">{{ entry.type }}</p>
+  <div class="tags" *ngIf="entry.tags?.length">
+    <span *ngFor="let tag of entry.tags">{{ tag }}</span>
+  </div>
+  <p class="content">{{ entry.content }}</p>
+  <div *ngIf="entry.relatedIds?.length">
+    <h3>Related</h3>
+    <ul>
+      <li *ngFor="let id of entry.relatedIds">
+        <a [routerLink]="['/entries', id]">{{ id }}</a>
+      </li>
+    </ul>
+  </div>
+  <p>
+    <a [routerLink]="['/entries', entry.id, 'edit']">Edit</a>
+  </p>
+</div>
+<ng-template #loading>Loading...</ng-template>

--- a/encyclopedia/src/app/components/entry-detail/entry-detail.component.scss
+++ b/encyclopedia/src/app/components/entry-detail/entry-detail.component.scss
@@ -1,0 +1,13 @@
+.type {
+  color: #6a5d4d;
+  font-style: italic;
+}
+.tags span {
+  margin-right: 0.5rem;
+  background: #ddd5c4;
+  padding: 0.2rem 0.4rem;
+}
+.content {
+  margin-top: 1rem;
+  white-space: pre-wrap;
+}

--- a/encyclopedia/src/app/components/entry-detail/entry-detail.component.ts
+++ b/encyclopedia/src/app/components/entry-detail/entry-detail.component.ts
@@ -1,0 +1,22 @@
+import { CommonModule } from '@angular/common';
+import { Component } from '@angular/core';
+import { ActivatedRoute, RouterModule } from '@angular/router';
+import { Observable } from 'rxjs';
+import { Entry } from '../../models/entry';
+import { EntryService } from '../../services/entry.service';
+
+@Component({
+  selector: 'app-entry-detail',
+  standalone: true,
+  imports: [CommonModule, RouterModule],
+  templateUrl: './entry-detail.component.html',
+  styleUrls: ['./entry-detail.component.scss']
+})
+export class EntryDetailComponent {
+  entry$: Observable<Entry | undefined>;
+
+  constructor(route: ActivatedRoute, private service: EntryService) {
+    const id = route.snapshot.paramMap.get('id')!;
+    this.entry$ = this.service.getEntry(id);
+  }
+}

--- a/encyclopedia/src/app/components/entry-form/entry-form.component.html
+++ b/encyclopedia/src/app/components/entry-form/entry-form.component.html
@@ -1,0 +1,33 @@
+<h2 *ngIf="entryId; else create">Edit Entry</h2>
+<ng-template #create><h2>Create Entry</h2></ng-template>
+<form [formGroup]="form" (ngSubmit)="save()">
+  <label>
+    Title
+    <input formControlName="title" required>
+  </label>
+  <label>
+    Type
+    <input formControlName="type" required>
+  </label>
+  <div formArrayName="tags">
+    <label>Tags</label>
+    <button type="button" (click)="addTag()">Add Tag</button>
+    <div *ngFor="let tag of tags.controls; let i=index">
+      <input [formControlName]="i">
+      <button type="button" (click)="removeTag(i)">Remove</button>
+    </div>
+  </div>
+  <label>
+    Content
+    <textarea formControlName="content" rows="6"></textarea>
+  </label>
+  <div formArrayName="relatedIds">
+    <label>Related Entry IDs</label>
+    <button type="button" (click)="addRelated()">Add Related</button>
+    <div *ngFor="let r of relatedIds.controls; let i=index">
+      <input [formControlName]="i">
+      <button type="button" (click)="removeRelated(i)">Remove</button>
+    </div>
+  </div>
+  <button type="submit">Save</button>
+</form>

--- a/encyclopedia/src/app/components/entry-form/entry-form.component.scss
+++ b/encyclopedia/src/app/components/entry-form/entry-form.component.scss
@@ -1,0 +1,13 @@
+form {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+label {
+  display: flex;
+  flex-direction: column;
+  font-weight: 600;
+}
+button {
+  margin-top: 0.5rem;
+}

--- a/encyclopedia/src/app/components/entry-form/entry-form.component.ts
+++ b/encyclopedia/src/app/components/entry-form/entry-form.component.ts
@@ -1,0 +1,83 @@
+import { CommonModule } from '@angular/common';
+import { Component } from '@angular/core';
+import { FormArray, FormBuilder, FormsModule, ReactiveFormsModule } from '@angular/forms';
+import { ActivatedRoute, Router, RouterModule } from '@angular/router';
+import { EntryService } from '../../services/entry.service';
+import { Entry } from '../../models/entry';
+import { switchMap, take } from 'rxjs';
+
+@Component({
+  selector: 'app-entry-form',
+  standalone: true,
+  imports: [CommonModule, FormsModule, ReactiveFormsModule, RouterModule],
+  templateUrl: './entry-form.component.html',
+  styleUrls: ['./entry-form.component.scss']
+})
+export class EntryFormComponent {
+  form = this.fb.group({
+    title: '',
+    type: '',
+    tags: this.fb.array<string>([]),
+    content: '',
+    relatedIds: this.fb.array<string>([])
+  });
+
+  get tags(): FormArray<string> {
+    return this.form.get('tags') as FormArray<string>;
+  }
+
+  get relatedIds(): FormArray<string> {
+    return this.form.get('relatedIds') as FormArray<string>;
+  }
+
+  entryId?: string;
+
+  constructor(
+    private fb: FormBuilder,
+    private service: EntryService,
+    private router: Router,
+    route: ActivatedRoute
+  ) {
+    const id = route.snapshot.paramMap.get('id');
+    if (id) {
+      this.entryId = id;
+      this.service.getEntry(id).pipe(take(1)).subscribe(entry => {
+        if (entry) {
+          this.form.patchValue({
+            title: entry.title,
+            type: entry.type,
+            content: entry.content
+          });
+          entry.tags?.forEach(t => this.tags.push(this.fb.control(t)));
+          entry.relatedIds?.forEach(r => this.relatedIds.push(this.fb.control(r)));
+        }
+      });
+    }
+  }
+
+  addTag() {
+    this.tags.push(this.fb.control(''));
+  }
+
+  removeTag(i: number) {
+    this.tags.removeAt(i);
+  }
+
+  addRelated() {
+    this.relatedIds.push(this.fb.control(''));
+  }
+
+  removeRelated(i: number) {
+    this.relatedIds.removeAt(i);
+  }
+
+  save() {
+    const value = this.form.value as Entry;
+    if (this.entryId) {
+      value.id = this.entryId;
+      this.service.updateEntry(value).then(() => this.router.navigate(['/entries', this.entryId]));
+    } else {
+      this.service.addEntry(value).then(ref => this.router.navigate(['/entries', ref.id]));
+    }
+  }
+}

--- a/encyclopedia/src/app/components/home/home.component.html
+++ b/encyclopedia/src/app/components/home/home.component.html
@@ -1,2 +1,3 @@
 <h1>Welcome to the Luminary Universe Encyclopedia</h1>
 <p>A place where stories, concepts, energies, and balance converge.</p>
+<p><a routerLink="/entries">Enter the Library</a></p>

--- a/encyclopedia/src/app/components/home/home.component.ts
+++ b/encyclopedia/src/app/components/home/home.component.ts
@@ -1,10 +1,11 @@
 import { Component } from '@angular/core';
 import { CommonModule } from '@angular/common';
+import { RouterLink } from '@angular/router';
 
 @Component({
   selector: 'app-home',
   standalone: true,
-  imports: [CommonModule],
+  imports: [CommonModule, RouterLink],
   templateUrl: './home.component.html',
   styleUrls: ['./home.component.scss']
 })

--- a/encyclopedia/src/app/models/entry.ts
+++ b/encyclopedia/src/app/models/entry.ts
@@ -1,0 +1,8 @@
+export interface Entry {
+  id?: string;
+  title: string;
+  type: string;
+  tags?: string[];
+  content: string;
+  relatedIds?: string[];
+}

--- a/encyclopedia/src/app/services/entry.service.ts
+++ b/encyclopedia/src/app/services/entry.service.ts
@@ -1,0 +1,34 @@
+import { inject, Injectable } from '@angular/core';
+import { collection, collectionData, doc, docData, Firestore, addDoc, updateDoc, deleteDoc } from '@angular/fire/firestore';
+import { Observable } from 'rxjs';
+import { Entry } from '../models/entry';
+
+@Injectable({ providedIn: 'root' })
+export class EntryService {
+  private firestore = inject(Firestore);
+  private entriesRef = collection(this.firestore, 'entries');
+
+  getEntries(): Observable<Entry[]> {
+    return collectionData(this.entriesRef, { idField: 'id' }) as Observable<Entry[]>;
+  }
+
+  getEntry(id: string): Observable<Entry | undefined> {
+    const entryDoc = doc(this.firestore, `entries/${id}`);
+    return docData(entryDoc, { idField: 'id' }) as Observable<Entry>;
+  }
+
+  addEntry(entry: Entry) {
+    return addDoc(this.entriesRef, entry);
+  }
+
+  updateEntry(entry: Entry) {
+    if (!entry.id) throw new Error('Entry ID missing');
+    const entryDoc = doc(this.firestore, `entries/${entry.id}`);
+    return updateDoc(entryDoc, { ...entry });
+  }
+
+  deleteEntry(id: string) {
+    const entryDoc = doc(this.firestore, `entries/${id}`);
+    return deleteDoc(entryDoc);
+  }
+}

--- a/encyclopedia/src/styles.scss
+++ b/encyclopedia/src/styles.scss
@@ -1,1 +1,11 @@
-/* You can add global styles to this file, and also import other style files */
+@import url('https://fonts.googleapis.com/css2?family=EB+Garamond&display=swap');
+body {
+  font-family: 'EB Garamond', serif;
+  background: #f5f2eb;
+  margin: 0;
+  color: #2c2c2c;
+}
+
+h1, h2, h3 {
+  color: #3d2b1f;
+}


### PR DESCRIPTION
## Summary
- create entry model and service for Firestore storage
- add list, detail, and form components
- wire up navigation and routes
- update global styles for an ancient library feel

## Testing
- `npm test` *(fails: no Chrome binary)*

------
https://chatgpt.com/codex/tasks/task_e_684437b1ab24832ea85c39cda41af4f2