### PR TITLE
Fix build error by updating Quill import

### DIFF
--- a/encyclopedia/angular.json
+++ b/encyclopedia/angular.json
@@ -48,7 +48,12 @@
                   "maximumError": "4kb"
                 }
               ],
-              "outputHashing": "all"
+              "outputHashing": "all",
+              "optimization": {
+                "fonts": {
+                  "inline": false
+                }
+              }
             },
             "development": {
               "optimization": false,

--- a/encyclopedia/src/index.html
+++ b/encyclopedia/src/index.html
@@ -6,6 +6,7 @@
   <base href="/">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <link rel="icon" type="image/x-icon" href="favicon.ico">
+  <link href="https://fonts.googleapis.com/css2?family=EB+Garamond&display=swap" rel="stylesheet">
 </head>
 <body>
   <app-root></app-root>

--- a/encyclopedia/src/styles.scss
+++ b/encyclopedia/src/styles.scss
@@ -1,5 +1,4 @@
-@import url('https://fonts.googleapis.com/css2?family=EB+Garamond&display=swap');
-@import '~quill/dist/quill.snow.css';
+@import 'quill/dist/quill.snow.css';
 body {
   font-family: 'EB Garamond', serif;
   background: #f5f2eb;


### PR DESCRIPTION
## Summary
- fix path to quill styles
- include font CSS via link element
- disable font inlining in production config

## Testing
- `npm run build -- --configuration production`
- `npm test --silent` *(fails: No binary for Chrome)*

------
https://chatgpt.com/codex/tasks/task_e_684455442830832eb21a1eeb171663d2