### PR TITLE
Category image upload and tile styles

### DIFF
--- a/encyclopedia/src/app/app.config.ts
+++ b/encyclopedia/src/app/app.config.ts
@@ -6,7 +6,17 @@ import { initializeApp, provideFirebaseApp } from '@angular/fire/app';
 import { getAuth, provideAuth } from '@angular/fire/auth';
 import { getAnalytics, provideAnalytics, ScreenTrackingService, UserTrackingService } from '@angular/fire/analytics';
 import { getFirestore, provideFirestore } from '@angular/fire/firestore';
+import { getStorage, provideStorage } from '@angular/fire/storage';
 
 export const appConfig: ApplicationConfig = {
-  providers: [provideRouter(routes), provideFirebaseApp(() => initializeApp({"projectId":"luminary-universe","appId":"1:124570023849:web:aa71e37bdedf565062f6b8","storageBucket":"luminary-universe.firebasestorage.app","apiKey":"AIzaSyBCbdHjNsm0BPhFC1ZMod_XVIlXmvDc0-U","authDomain":"luminary-universe.firebaseapp.com","messagingSenderId":"124570023849","measurementId":"G-HW37Y2D6DE"})), provideAuth(() => getAuth()), provideAnalytics(() => getAnalytics()), ScreenTrackingService, UserTrackingService, provideFirestore(() => getFirestore())]
+  providers: [
+    provideRouter(routes),
+    provideFirebaseApp(() => initializeApp({"projectId":"luminary-universe","appId":"1:124570023849:web:aa71e37bdedf565062f6b8","storageBucket":"luminary-universe.firebasestorage.app","apiKey":"AIzaSyBCbdHjNsm0BPhFC1ZMod_XVIlXmvDc0-U","authDomain":"luminary-universe.firebaseapp.com","messagingSenderId":"124570023849","measurementId":"G-HW37Y2D6DE"})),
+    provideAuth(() => getAuth()),
+    provideAnalytics(() => getAnalytics()),
+    ScreenTrackingService,
+    UserTrackingService,
+    provideFirestore(() => getFirestore()),
+    provideStorage(() => getStorage())
+  ]
 };

--- a/encyclopedia/src/app/components/categories/categories.component.html
+++ b/encyclopedia/src/app/components/categories/categories.component.html
@@ -1,7 +1,9 @@
 <h2>Categories</h2>
 <div class="categories">
-  <a *ngFor="let c of categories$ | async" [routerLink]="['/categories', c.id, 'edit']" class="category-link">
-    <img [src]="c.imageUrl" [alt]="c.name" />
+  <a *ngFor="let c of categories$ | async"
+     [routerLink]="['/categories', c.id, 'edit']"
+     class="category-link"
+     [ngStyle]="{'background-image': 'url(' + c.imageUrl + ')'}">
     <h3>{{ c.name }}</h3>
   </a>
 </div>

--- a/encyclopedia/src/app/components/categories/categories.component.scss
+++ b/encyclopedia/src/app/components/categories/categories.component.scss
@@ -5,16 +5,21 @@
 }
 .category-link {
   flex: 1 1 200px;
-  padding: 1rem;
-  background: #f8f5f0;
+  height: 150px;
+  background-size: cover;
+  background-position: center;
   border: 1px solid #ddd5c4;
   text-decoration: none;
-  color: inherit;
-  text-align: center;
-  img {
+  color: #fff;
+  display: flex;
+  align-items: flex-end;
+  justify-content: center;
+  h3 {
+    margin: 0;
     width: 100%;
-    height: 150px;
-    object-fit: cover;
+    background: rgba(0, 0, 0, 0.6);
+    padding: 0.5rem;
+    text-align: center;
   }
 }
 .empty {

--- a/encyclopedia/src/app/components/category-form/category-form.component.html
+++ b/encyclopedia/src/app/components/category-form/category-form.component.html
@@ -6,8 +6,9 @@
     <input formControlName="name" required>
   </label>
   <label>
-    Image URL
-    <input formControlName="imageUrl" required>
+    Image
+    <input type="file" (change)="uploadImage($event)" accept="image/*" required>
   </label>
+  <img *ngIf="form.value.imageUrl" class="preview" [src]="form.value.imageUrl" alt="Preview" />
   <button type="submit">Save</button>
 </form>

--- a/encyclopedia/src/app/components/category-form/category-form.component.scss
+++ b/encyclopedia/src/app/components/category-form/category-form.component.scss
@@ -11,3 +11,9 @@ label {
 button {
   margin-top: 0.5rem;
 }
+
+.preview {
+  width: 200px;
+  height: auto;
+  border: 1px solid #ddd5c4;
+}

--- a/encyclopedia/src/app/components/category-form/category-form.component.ts
+++ b/encyclopedia/src/app/components/category-form/category-form.component.ts
@@ -1,10 +1,11 @@
 import { CommonModule } from '@angular/common';
-import { Component } from '@angular/core';
+import { Component, inject } from '@angular/core';
 import { FormBuilder, FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { ActivatedRoute, Router, RouterModule } from '@angular/router';
 import { take } from 'rxjs';
 import { Category } from '../../models/category';
 import { CategoryService } from '../../services/category.service';
+import { Storage, ref, uploadBytes, getDownloadURL } from '@angular/fire/storage';
 
 @Component({
   selector: 'app-category-form',
@@ -18,6 +19,8 @@ export class CategoryFormComponent {
     name: this.fb.nonNullable.control(''),
     imageUrl: this.fb.nonNullable.control('')
   });
+
+  private storage = inject(Storage);
 
   categoryId?: string;
 
@@ -36,6 +39,15 @@ export class CategoryFormComponent {
         }
       });
     }
+  }
+
+  uploadImage(event: Event) {
+    const file = (event.target as HTMLInputElement).files?.[0];
+    if (!file) return;
+    const fileRef = ref(this.storage, `categories/${Date.now()}_${file.name}`);
+    uploadBytes(fileRef, file)
+      .then(() => getDownloadURL(fileRef))
+      .then(url => this.form.patchValue({ imageUrl: url }));
   }
 
   save() {

--- a/encyclopedia/src/app/components/entry-form/entry-form.component.scss
+++ b/encyclopedia/src/app/components/entry-form/entry-form.component.scss
@@ -11,3 +11,10 @@ label {
 button {
   margin-top: 0.5rem;
 }
+
+quill-editor {
+  .ql-container {
+    height: 200px;
+  }
+  margin-bottom: 1rem;
+}

--- a/encyclopedia/src/app/components/home/home.component.html
+++ b/encyclopedia/src/app/components/home/home.component.html
@@ -1,8 +1,11 @@
 <h1>Welcome to the Luminary Universe Encyclopedia</h1>
 <p>A place where stories, concepts, energies, and balance converge.</p>
 <div class="categories">
-  <a *ngFor="let c of categories$ | async" [routerLink]="['/entries']" [queryParams]="{category: c.id}" class="category">
-    <img [src]="c.imageUrl" [alt]="c.name" />
+  <a *ngFor="let c of categories$ | async"
+     [routerLink]="['/entries']"
+     [queryParams]="{category: c.id}"
+     class="category"
+     [ngStyle]="{'background-image': 'url(' + c.imageUrl + ')'}">
     <h3>{{ c.name }}</h3>
   </a>
 </div>

--- a/encyclopedia/src/app/components/home/home.component.scss
+++ b/encyclopedia/src/app/components/home/home.component.scss
@@ -12,15 +12,20 @@
 
 .category {
   flex: 1 1 200px;
+  height: 150px;
   text-decoration: none;
-  color: inherit;
-  background: #f8f5f0;
+  color: #fff;
+  background-size: cover;
+  background-position: center;
   border: 1px solid #ddd5c4;
-  padding: 0.5rem;
-  text-align: center;
-  img {
+  display: flex;
+  align-items: flex-end;
+  justify-content: center;
+  h3 {
+    margin: 0;
     width: 100%;
-    height: 150px;
-    object-fit: cover;
+    background: rgba(0, 0, 0, 0.6);
+    padding: 0.5rem;
+    text-align: center;
   }
 }


### PR DESCRIPTION
## Summary
- enable Firebase storage
- allow uploading category image and preview
- show categories as image tiles on home and category list pages
- tidy entry form rich text editor spacing

## Testing
- `npm test` *(fails: No binary for Chrome browser)*

------
https://chatgpt.com/codex/tasks/task_e_68446de8b460832e839009f07eb73a5c