### PR TITLE
Improve site theming and category display

### DIFF
--- a/encyclopedia/src/app/app.component.scss
+++ b/encyclopedia/src/app/app.component.scss
@@ -1,10 +1,10 @@
 nav {
-  background: #eae3d8;
+  background: var(--nav-bg-color);
   padding: 0.5rem 1rem;
   display: flex;
   gap: 1rem;
   a {
     text-decoration: none;
-    color: #333;
+    color: var(--dark-text);
   }
 }

--- a/encyclopedia/src/app/components/categories/categories.component.html
+++ b/encyclopedia/src/app/components/categories/categories.component.html
@@ -3,7 +3,7 @@
   <a *ngFor="let c of categories$ | async"
      [routerLink]="['/categories', c.id, 'edit']"
      class="category-link"
-     [ngStyle]="{'background-image': 'url(' + c.imageUrl + ')'}">
+     [style.backgroundImage]="'url(' + c.imageUrl + ')'">
     <h3>{{ c.name }}</h3>
   </a>
 </div>

--- a/encyclopedia/src/app/components/categories/categories.component.scss
+++ b/encyclopedia/src/app/components/categories/categories.component.scss
@@ -1,3 +1,8 @@
+:host {
+  display: block;
+  padding: 1rem;
+}
+
 .categories {
   display: flex;
   flex-wrap: wrap;
@@ -8,7 +13,7 @@
   height: 150px;
   background-size: cover;
   background-position: center;
-  border: 1px solid #ddd5c4;
+  border: 1px solid var(--accent-color);
   text-decoration: none;
   color: #fff;
   display: flex;

--- a/encyclopedia/src/app/components/category-form/category-form.component.scss
+++ b/encyclopedia/src/app/components/category-form/category-form.component.scss
@@ -1,3 +1,8 @@
+:host {
+  display: block;
+  padding: 1rem;
+}
+
 form {
   display: flex;
   flex-direction: column;
@@ -15,5 +20,5 @@ button {
 .preview {
   width: 200px;
   height: auto;
-  border: 1px solid #ddd5c4;
+  border: 1px solid var(--accent-color);
 }

--- a/encyclopedia/src/app/components/entries/entries.component.scss
+++ b/encyclopedia/src/app/components/entries/entries.component.scss
@@ -1,3 +1,8 @@
+:host {
+  display: block;
+  padding: 1rem;
+}
+
 .entries {
   display: flex;
   flex-wrap: wrap;
@@ -6,18 +11,18 @@
 .entry-link {
   flex: 1 1 200px;
   padding: 1rem;
-  background: #f8f5f0;
-  border: 1px solid #ddd5c4;
+  background: var(--bg-color);
+  border: 1px solid var(--accent-color);
   text-decoration: none;
   color: inherit;
 }
 .type {
   font-size: 0.8rem;
-  color: #6a5d4d;
+  color: var(--muted-text);
 }
 .category {
   font-size: 0.75rem;
-  color: #333;
+  color: var(--dark-text);
 }
 .empty {
   font-style: italic;

--- a/encyclopedia/src/app/components/entry-detail/entry-detail.component.scss
+++ b/encyclopedia/src/app/components/entry-detail/entry-detail.component.scss
@@ -1,10 +1,15 @@
+:host {
+  display: block;
+  padding: 1rem;
+}
+
 .type {
-  color: #6a5d4d;
+  color: var(--muted-text);
   font-style: italic;
 }
 .tags span {
   margin-right: 0.5rem;
-  background: #ddd5c4;
+  background: var(--accent-color);
   padding: 0.2rem 0.4rem;
 }
 .content {

--- a/encyclopedia/src/app/components/entry-form/entry-form.component.scss
+++ b/encyclopedia/src/app/components/entry-form/entry-form.component.scss
@@ -1,3 +1,8 @@
+:host {
+  display: block;
+  padding: 1rem;
+}
+
 form {
   display: flex;
   flex-direction: column;

--- a/encyclopedia/src/app/components/home/home.component.html
+++ b/encyclopedia/src/app/components/home/home.component.html
@@ -5,7 +5,7 @@
      [routerLink]="['/entries']"
      [queryParams]="{category: c.id}"
      class="category"
-     [ngStyle]="{'background-image': 'url(' + c.imageUrl + ')'}">
+     [style.backgroundImage]="'url(' + c.imageUrl + ')'">
     <h3>{{ c.name }}</h3>
   </a>
 </div>

--- a/encyclopedia/src/app/components/home/home.component.scss
+++ b/encyclopedia/src/app/components/home/home.component.scss
@@ -17,7 +17,7 @@
   color: #fff;
   background-size: cover;
   background-position: center;
-  border: 1px solid #ddd5c4;
+  border: 1px solid var(--accent-color);
   display: flex;
   align-items: flex-end;
   justify-content: center;

--- a/encyclopedia/src/styles.scss
+++ b/encyclopedia/src/styles.scss
@@ -1,11 +1,21 @@
 @import 'quill/dist/quill.snow.css';
+:root {
+  --bg-color: #f5f2eb;
+  --text-color: #2c2c2c;
+  --accent-color: #ddd5c4;
+  --nav-bg-color: #eae3d8;
+  --heading-color: #3d2b1f;
+  --muted-text: #6a5d4d;
+  --dark-text: #333;
+}
+
 body {
   font-family: 'EB Garamond', serif;
-  background: #f5f2eb;
+  background: var(--bg-color);
   margin: 0;
-  color: #2c2c2c;
+  color: var(--text-color);
 }
 
 h1, h2, h3 {
-  color: #3d2b1f;
+  color: var(--heading-color);
 }


### PR DESCRIPTION
## Summary
- add CSS variables for a shared theme
- convert component styles to use theme variables
- add consistent padding to all page components
- fix category image binding

## Testing
- `npm install --prefix encyclopedia`
- `npm test --prefix encyclopedia` *(fails: Chrome binary missing)*

------
https://chatgpt.com/codex/tasks/task_e_68449b8b70c4832eb3ab2b5c77366896